### PR TITLE
Exported methods are passed as arguments to the job - added test for file inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ Here's a code snippet, make good use of it.
 const http = require('http');
 const { spawn, send } = require('hoverlord');
 
-spawn(() => {
-  const { receive } = require('hoverlord');
+spawn(({ receive }) => {
   receive((_state, { content }) => {
     console.log(`log: ${message}`);
   });
 }, 'logger');
 
-spawn(() => {
-  const { receive, send } = require('hoverlord');
+spawn(({ receive, send }) => {
   return receive((state, message) => {
     switch (message.content) {
       case 'ping':

--- a/hoverlord.test.js
+++ b/hoverlord.test.js
@@ -5,8 +5,7 @@ const findDuplicates = (arr) =>
 
 describe('hoverlord', () => {
   it('can call from the main process', async () => {
-    await spawn(() => {
-      const { receive, reply } = require('./index');
+    await spawn(({ receive, reply }) => {
       return receive((state, message) => {
         switch (message.content) {
           case 'ping':
@@ -30,8 +29,7 @@ describe('hoverlord', () => {
   });
 
   it('can call a process from another process', async () => {
-    await spawn(() => {
-      const { receive, reply } = require('./index');
+    await spawn(({ receive, reply }) => {
       return receive(
         (state, message) => {
           if (
@@ -49,8 +47,7 @@ describe('hoverlord', () => {
       );
     }, 'statefulActor');
 
-    await spawn(() => {
-      const { receive, reply, call } = require('./index');
+    await spawn(({ receive, reply, call }) => {
       return receive((state, message) => {
         switch (message.content) {
           case 'do_the_call': {
@@ -84,8 +81,7 @@ describe('hoverlord', () => {
   });
 
   it('should not create duplicate fingerprints', async () => {
-    await spawn(() => {
-      const { receive, reply } = require('./index');
+    await spawn(({ receive, reply }) => {
       return receive((_, message) => {
         const [term, count] = message.content;
         if (term === 'ping') {

--- a/index.js
+++ b/index.js
@@ -14,9 +14,10 @@ const isFromWorker = (payload) => Boolean(payload.fromWorker);
 
 const createFingerprint = () => crypto.randomBytes(64).toString('hex');
 
-const createWorkerContent = (jobCode) => `
-  (${jobCode})();
-`;
+const createWorkerContent = (jobCode) => {
+  const hoverlordFile = __filename.replace(/\\/g, '\\\\'); // in case of windows system
+  return `(${jobCode})(require('${hoverlordFile}'));`;
+}
 
 const spawn = (job, name) => {
   return new Promise((resolve) => {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,7 @@ const isFromWorker = (payload) => Boolean(payload.fromWorker);
 const createFingerprint = () => crypto.randomBytes(64).toString('hex');
 
 const createWorkerContent = (jobCode) => {
-  const hoverlordFile = __filename.replace(/\\/g, '\\\\'); // in case of windows system
-  return `(${jobCode})(require('${hoverlordFile}'));`;
+  return `(${jobCode})(require(${JSON.stringify(__filename)}));`;
 }
 
 const spawn = (job, name) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   transform: {},
+  "testRegex": "./test/.*.test.js$"
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  transform: {},
-  "testRegex": "./test/.*.test.js$"
+  transform: {}
 };

--- a/test/hoverlord.test.js
+++ b/test/hoverlord.test.js
@@ -1,4 +1,4 @@
-const { spawn, call, send, shutdown } = require('./index');
+const { spawn, call, send, shutdown } = require('./../index');
 
 const findDuplicates = (arr) =>
   arr.filter((item, index) => arr.indexOf(item) != index);
@@ -103,4 +103,23 @@ describe('hoverlord', () => {
     const duplicates = [...new Set(findDuplicates(fingerprints))];
     expect(duplicates).toHaveLength(0);
   });
+
+  it('should be able to include files', async () => {
+    await spawn(({ receive, reply }) => {
+      return receive((_, message) => {
+        const answer = require('./test/includes/export-42');
+        const [term] = message.content;
+        if (term === 'ping') {
+          reply(message, ['pong', answer]);
+        }
+      });
+    }, 'receiver');
+
+    const response = await call('receiver', ['ping']);
+
+    shutdown();
+
+    expect(response.content).toEqual(['pong', 42]);
+  });
+
 });

--- a/test/includes/export-42.js
+++ b/test/includes/export-42.js
@@ -1,0 +1,1 @@
+module.exports = 42;


### PR DESCRIPTION
## COMMIT d682c1e2a048010d4ca7325a7804be69ec00ce71:
With this commit the job has now as first argument all the hoverlord exported methods.
```js
spawn(({ receive, send, call }) => {
  return receive((state, message) => {
       // stuff
  }
});
```

so, we are not forced to include hoverlord explicitly inside the job. This is **NOT** a breaking change because you can still do it.

Due the fact that it should be the recommended way to operate, the commit modifies all the tests and the README file.



## COMMIT 95fd3643230cdda7205d7c623d57afd851f4a886:

Added test for file inclusion inside the job.

I moved the hoverlord.test.js file in test directory and changed the jest config accordingly. I had to create a dummy file for this and it was better to put it inside a test directory instead of put it inside the root. Having a test directory, it makes sense to put all test files here.


