### PR TITLE
feat: spawn method accepts vars to clone and pass to the worker

### DIFF
--- a/test/hoverlord.test.js
+++ b/test/hoverlord.test.js
@@ -147,4 +147,28 @@ describe('hoverlord', () => {
 
     expect(result).toBe(3);
   });
+
+  it('should pass the target object to the job', async () => {
+    const object1 = {
+      simpleKey1: 'simpleValue1'
+    };
+    const object2 = {
+      simpleKey2: 'simpleValue2'
+    };
+
+    await spawn(({receive, reply}) => {
+      return receive((_, message) => {
+        const [term] = message.content;
+        if (term === 'ping') {
+          reply(message, ['pong', object1.simpleKey1, object2.simpleKey2]);
+        }
+      });
+    }, 'receiver', {object1, object2});
+
+    const response = await call('receiver', ['ping']);
+
+    shutdown();
+
+    expect(response.content).toEqual(['pong', 'simpleValue1', 'simpleValue2']);
+  });
 });


### PR DESCRIPTION
Use case of the feature:

```js
const hello = "world"; // var to clone

await spawn(({receive, reply}) => {
	console.log(hello); // world
	// ...
}, 'receiver', {hello});
```

Variables are passed through the option [`workerData` ](https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options) of `Worker` constructor and fetched inside the Worker code with `require('worker_threads').workerData` as documentation suggests.



