### PR TITLE
typo: correct example, logger receive content and not message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Hoverlord
+
 Actor model library and concurrency primitives for NodeJS.
 
 ## Usage
+
 Here's a code snippet, make good use of it.
 
 ```js
@@ -10,7 +12,7 @@ const { spawn, send } = require('hoverlord');
 
 spawn(({ receive }) => {
   receive((_state, { content }) => {
-    console.log(`log: ${message}`);
+    console.log(`log: ${content}`);
   });
 }, 'logger');
 
@@ -37,6 +39,7 @@ http
 ```
 
 ## But wait: what the heck is the actor model anyway?
+
 [Wikipedia](https://en.wikipedia.org/wiki/Actor_model) summarizes it this way:
 
 > The actor model in computer science is a mathematical model of concurrent computation that treats actor as the universal primitive of concurrent computation. In response to a message it receives, an actor can: make local decisions, create more actors, send more messages, and determine how to respond to the next message received. Actors may modify their own private state, but can only affect each other indirectly through messaging (removing the need for lock-based synchronization).


### PR DESCRIPTION
Correct example in RADME. Actor `logger` parameter in `content`.